### PR TITLE
`few_shot_dataloader` utility function refactor

### DIFF
--- a/data_utils/DCASEfewshot.py
+++ b/data_utils/DCASEfewshot.py
@@ -32,6 +32,8 @@ import json
 import csv
 import matplotlib.pyplot as plt
 from copy import copy
+from .dataset import TaskSampler
+from torch.utils.data import Dataset, DataLoader
 
 PLOT = False
 PLOT_TOO_SHORT_SAMPLES = False
@@ -41,6 +43,32 @@ def normalize_mono(samples):
     current_max = max(np.amax(samples), -np.amin(samples))
     scale = 0.99 / current_max
     return np.multiply(samples, scale)
+
+
+def few_shot_dataloader(
+    df: Dataset,
+    n_way: int,
+    n_shot: int,
+    n_query: int,
+    n_tasks: int,
+    tensor_length: int = 0
+) -> DataLoader:
+
+    sampler = TaskSampler(
+        df,
+        n_way=n_way,  # number of classes
+        n_shot=n_shot,  # Number of images PER CLASS in the support set
+        n_query=n_query,  # Number of images PER CLASSS in the query set
+        n_tasks=n_tasks,  # Not sure
+        tensor_length=tensor_length,
+    )
+
+    return DataLoader(
+        df,
+        batch_sampler=sampler,
+        pin_memory=False,
+        collate_fn=sampler.episodic_collate_fn,
+    )
 
 
 def preprocess(

--- a/datamodules/DCASEDataModule.py
+++ b/datamodules/DCASEDataModule.py
@@ -10,7 +10,7 @@ from sklearn.preprocessing import LabelEncoder
 from sklearn.model_selection import train_test_split
 from pytorch_lightning import LightningDataModule
 import torch
-from data_utils.dataset import TaskSampler
+from data_utils.DCASEfewshot import few_shot_dataloader
 import numpy as np
 
 
@@ -47,37 +47,6 @@ class AudioDatasetDCASE(Dataset):
         label = self.label_encoder.transform([label])[0]
 
         return input_feature, label
-
-
-def few_shot_dataloader(df, n_way, n_shot, n_query, n_tasks, tensor_length):
-    """
-    root_dir: directory where the audio data is stored
-    data_frame: path to the label file
-    n_way: number of classes
-    n_shot: number of images PER CLASS in the support set
-    n_query: number of images PER CLASSS in the query set
-    n_tasks: number of episodes (number of times the loader gives the data during a training step)
-    """
-
-    # df = AudioDataset(root_dir=root_dir, data_frame=data_frame, transform=transform)
-
-    sampler = TaskSampler(
-        df,
-        n_way=n_way,  # number of classes
-        n_shot=n_shot,  # Number of images PER CLASS in the support set
-        n_query=n_query,  # Number of images PER CLASSS in the query set
-        n_tasks=n_tasks,  # Not sure
-        tensor_length=128,
-    )
-
-    loader = DataLoader(
-        df,
-        batch_sampler=sampler,
-        pin_memory=False,
-        collate_fn=sampler.episodic_collate_fn,
-    )
-
-    return loader
 
 
 class DCASEDataModule(LightningDataModule):


### PR DESCRIPTION
It seems the `few_shot_dataloader` function has been defined twice and as this is more of an utility function, it's better to define it once and reuse it when needed.

Also there is another issue as well, which is, [here on line 70 of `datamodules/DCASEDataModule.py`](https://github.com/NINAnor/rare_species_detections/blob/6b7695b5fe2bb12bbe811a469e086b78ce956b81/datamodules/DCASEDataModule.py#L70) file the `tensor_length` value is explicitly set to 128, which make the `tensor_length` parameter unused when passing the argument. For example [line 182](https://github.com/NINAnor/rare_species_detections/blob/6b7695b5fe2bb12bbe811a469e086b78ce956b81/datamodules/DCASEDataModule.py#LL182C13-L182C46) or [line 193](https://github.com/NINAnor/rare_species_detections/blob/6b7695b5fe2bb12bbe811a469e086b78ce956b81/datamodules/DCASEDataModule.py#L193) of the same file. Here the `self.tensor_length` property is already set to 128, therefore you didn't get any error till now I guess. 🤔 

And for the similarity sake I have put the `few_shot_dataloader` function in `data_utils/DCASEfewshot.py` file which made more sense to me as this utility function is closely related the code this directory. Plus also simplified the code a bit by early returning some outputs.

However, one thing I need to clarify that, this refactor is based on my reading of this codebase. Therefore, please test this PR before merging.