### PR TITLE
[FIX] Handling command line inputs, status, and set_type

### DIFF
--- a/CONFIG.yaml
+++ b/CONFIG.yaml
@@ -20,8 +20,7 @@ data:
   n_query: 10
   overlap: 0.5
   n_subsample: 1 # ask Femke what this stands for
-  status: validate # train or validate or evaluate
-  set_type: Validation_Set # Training_Set or Validation_Set or Evaluation_Set
+  status: train # train or validate or evaluate
 
 #################################
 # PARAMETERS FOR MODEL TRAINING #
@@ -37,7 +36,7 @@ trainer:
 model:
   distance: euclidean # other option is mahalanobis
   lr: 1.0e-05
-  model_path: /data/lightning_logs/version_0/checkpoints/epoch=14-step=1500.ckpt # /data/BEATs/BEATs_iter3_plus_AS2M.pt # Or FOR INFERENCE: /data/lightning_logs/version_X/checkpoints/epoch=X-step=1500.ckpt
+  model_path: /data/BEATs/BEATs_iter3_plus_AS2M.pt # Or FOR INFERENCE: /data/lightning_logs/version_X/checkpoints/epoch=X-step=1500.ckpt
 
 
 ##################################################################

--- a/data_utils/DCASEfewshot.py
+++ b/data_utils/DCASEfewshot.py
@@ -560,19 +560,8 @@ if __name__ == "__main__":
     )
 
 
-    # check input
+    # get input
     cli_args = parser.parse_args()
-    assert (
-        cli_args.status == "validate"
-        or cli_args.status == "train"
-        or cli_args.status == "test"
-    )
-    if cli_args.status == "validate":
-        assert cli_args.set_type == "Validation_Set"
-    elif cli_args.status == "train":
-        assert cli_args.set_type == "Training_Set"
-    elif cli_args.status == "test":
-        assert cli_args.set_type == "Evaluation_Set"
 
     # Open the config file
     import yaml
@@ -580,6 +569,21 @@ if __name__ == "__main__":
 
     with open(cli_args.config) as f:
         cfg = yaml.load(f, Loader=FullLoader)
+
+    # Check values in config file
+    if not (cfg["data"]["status"]=="train" or cfg["data"]["status"]=="validate" or cfg["data"]["status"]=="test"):
+        raise Exception("ERROR: "+ str(cli_args.config) + ": Accepted values for 'status' are 'train', 'validate', or 'test'. Received '" + str(cfg["data"]["status"]) + "'.")
+    
+    # Select 'set_type' depending on chosen status
+    if cfg["data"]["status"]=="train":
+        cfg["data"]["set_type"] = "Training_Set"
+
+    elif cfg["data"]["status"]=="validate":
+        cfg["data"]["set_type"] = "Validation_Set"
+
+    else:
+        cfg["data"]["set_type"] = "Evaluation_Set"
+    
 
     prepare_training_val_data(
         cfg["data"]["status"],


### PR DESCRIPTION
Small fix to remove the 'status' and 'set_type' from the command line inputs, rather we pick them from the config.yaml file. Additionally, 'set_type' is inferred directly from 'status' so we don't need to repeat it. An exception is raised if 'status' is none of the accepted keywords.